### PR TITLE
Add find and debug function

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,4 +1,8 @@
 [[https://melpa.org/#/ros][file:https://melpa.org/packages/ros-badge.svg]]
+
+* Juraph's personal fork of ROS.el
+Largest change is the addition of a "debug" flag, which allows the user to run a node through the emacs-gdb interface. works for both ros-2 and ros-1, supporting standalone executables and nodelets. There is a video of the addition [[https://juraph.com/miscellaneous/ros_emacs_debugging][on a blog post]] covering the process.
+
 * ros.el
 :PROPERTIES:
 :CREATED:  [2021-07-30 Fri 09:36]

--- a/ros.el
+++ b/ros.el
@@ -8,7 +8,7 @@
 ;; Version: 1.0.0
 ;; Keywords: convenience tools
 ;; Homepage: https://github.com/DerBeutlin/ros.el
-;; Package-Requires: ((emacs "27.1") s with-shell-interpreter kv cl-lib transient hydra grep string-inflection)
+;; Package-Requires: ((emacs "29.1") s with-shell-interpreter kv cl-lib transient hydra grep string-inflection)
 ;;
 ;; This file is not part of GNU Emacs.
 ;;
@@ -42,10 +42,7 @@
 (require 'hydra)
 (require 'grep)
 (require 'string-inflection)
-(eval-and-compile
-  (if (>= emacs-major-version 29)
-      (require 'tramp-container)
-    (require 'docker-tramp)))
+(require 'tramp-container)
 
 (defvar ros-tramp-prefix "")
 

--- a/ros.el
+++ b/ros.el
@@ -675,6 +675,8 @@
    ("-C" "Use CCache" "--cmake-args \"-DCMAKE_C_COMPILER_LAUNCHER=ccache\" \"-DCMAKE_CXX_COMPILER_LAUNCHER=ccache\"")
    ("-fc" "force CMake configure step" "--cmake-force-configure")
    ("-s" "Use symlinks instead of copying files where possible" "--symlink-install")
+   ("-m" "Merge packages for install" "--merge-install")
+   ("-d" "Use console direct for output" "--event-handlers console_direct+")
    (ros-colcon-build-transient:--DCMAKE_BUILD_TYPE)
    (ros-colcon-build-transient:--DCMAKE_EXPORT_COMPILE_COMMANDS)
    (ros-colcon-build-transient:--parallel-workers)]

--- a/ros.el
+++ b/ros.el
@@ -643,7 +643,7 @@
          (trimmed-package-list (delete-dups (ros-remove-every-second-item package-list)))
          (package (completing-read "Package: " trimmed-package-list nil t))
          (executables (split-string (ros-shell-command-to-string (format "ros2 pkg executables %s" package))))
-         (filtered-executables (seq-filter (lambda (exe) (not (string-prefix-p package exe))) executables))
+         (filtered-executables (cl-remove-if-not #'(lambda (x) (not (zerop (% (cl-position x executables) 2)))) executables))
          (executable (completing-read "Executable: " filtered-executables nil t))
          (prefix (ros-shell-command-to-string (format "ros2 pkg prefix %s" package)))
          (gdb-command (if (ros-current-tramp-prefix)

--- a/ros.el
+++ b/ros.el
@@ -513,8 +513,8 @@
          (verb (cdr (assoc "verb" action)))
          (flags (cdr (assoc "flags" action)))
          (post-cmd (cdr (assoc "post-cmd" action))))
+    (concat source-command " && cd " (ros-current-workspace) " && colcon " verb " " (when flags (string-join flags " ")) (when post-cmd (concat " && " post-cmd)))))
 
-    (concat source-command " && colcon " verb " " (when flags (string-join flags " ")) (when post-cmd (concat " && " post-cmd)))))
 
 (defun ros-compile-action (action)
   (interactive (list (ros-completing-read-colcon-action-from-history)))


### PR DESCRIPTION
G'day,

This PR adds a simple debug head to the hydra, allowing a user to easily run a ros2 node through emacs-gdb. Works for local, and remote work-spaces through Tramp, including through a remote docker instance. 

I would like to extend the hydra with more options, but I wanted to gauge your thoughts on this before getting too far into it.